### PR TITLE
Added a way to override package sources to be installed from Gemfury

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,37 @@ moment:          implicitly found and installed from fury-org
 jquery:          installed from public registry after not finding it in fury-org
 ```
 
+## Overriding package sources
+
+It is possible to override packages matching a specified source to be fetched from Gemfury.
+One of the use cases is when a child dependency itself depends on private package hosted on Github
+and you want to install it via Gemfury instead.
+
+Child dependency `bower.json` can contain something like this:
+
+```json
+{
+  "dependencies": {
+    "my-private-package": "git@github.com:my-org/my-private-package#1.2.3"
+  }
+}
+```
+
+To force `my-private-package` to come from Gemfury without modifying that child
+ `bower.json`, add the following to your `.bowerrc`:
+
+```json
+"furyResolver": {
+  "sourceOverrides": [
+    {
+      "source": "^git@github.com:\/?my-org/(.+?)(\\.git)?$",
+      "override": "fury:\/\/my-org/$1"
+    }
+  ]
+}
+```
+
+
 ## Contribution and Improvements
 
 Please [email us](mailto:support@gemfury.com) if we've missed some key

--- a/lib/fury.js
+++ b/lib/fury.js
@@ -16,6 +16,9 @@ function Fury(bower) {
   // Auto-locate packages in a specified account
   this.locateInAccount = fury.locateInAccount;
   this.accountPackageNames = null;
+
+  // Override packages sources
+  this.sourceOverrides = fury.sourceOverrides || [];
 }
 
 // Request fury:// as https://bower.fury.io/...
@@ -73,6 +76,20 @@ Fury.prototype.buildURI = function() {
   var parts = Array.prototype.slice.call(arguments);
   parts[0] = parts[0] || this.locateInAccount;
   return FURY_SRC_PREFIX + parts.join('/');
+}
+
+// Override source url if required
+Fury.prototype.applyOverrides = function(source) {
+  var matchedRules = this.sourceOverrides.filter(function(rule) {
+    return (new RegExp(rule.source)).test(source);
+  });
+
+  if (matchedRules.length > 0) {
+    var matchedRule = matchedRules[0];
+    return source.replace(new RegExp(matchedRule.source), matchedRule.override);
+  } else {
+    return source;
+  }
 }
 
 // Unleash the Fury!!!

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,11 +18,13 @@ module.exports = function resolver (bower) {
   return {
     // Checks if fury:// source or is auto-located
     match: function (source) {
+      source = fury.applyOverrides(source);
       return fury.matchPromise(source);
     },
 
     // Rewrite package names to fury:// as needed
     locate: function (source) {
+     source = fury.applyOverrides(source);
      return fury.matchPromise(source).then(function(isMatch) {
         if(isMatch && !fury.isFuryURI(source)) {
           return fury.buildURI(null, source);          
@@ -34,7 +36,8 @@ module.exports = function resolver (bower) {
 
     // List available versions for given source
     releases: function (source) {
-      return fury.sourceRequest(source).then(function(info) {
+        source = fury.applyOverrides(source);
+        return fury.sourceRequest(source).then(function(info) {
         return info['_versions'].map(function(v) {
           return { target: v, version: v};
         });


### PR DESCRIPTION
## Overriding package sources

It is possible to override packages matching a specified source to be fetched from Gemfury.
One of the use cases is when a child dependency itself depends on private package hosted on Github
and you want to install it via Gemfury instead.

Child dependency `bower.json` can contain something like this:

```json
{
  "dependencies": {
    "my-private-package": "git@github.com:my-org/my-private-package#1.2.3"
  }
}
```

To force `my-private-package` to come from Gemfury without modifying that child
 `bower.json`, add the following to your `.bowerrc`:

```json
"furyResolver": {
  "sourceOverrides": [
    {
      "source": "^git@github.com:\/?my-org/(.+?)(\\.git)?$",
      "override": "fury:\/\/my-org/$1"
    }
  ]
}
```
